### PR TITLE
Add subtle viewport gradient and grid toggle

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,7 +107,7 @@ export class Renderer {
 
     private constructor() {
         const webgl2Context = (<HTMLCanvasElement>document.getElementById('canvas')).getContext('webgl2', {
-            alpha: false,
+            alpha: true,
         });
 
         if (webgl2Context === null) {
@@ -662,7 +662,7 @@ export class Renderer {
 
         this._gl.enable(this._gl.DEPTH_TEST);
         this._gl.enable(this._gl.BLEND);
-        this._gl.clearColor(this._backgroundColour.r, this._backgroundColour.g, this._backgroundColour.b, 1.0);
+        this._gl.clearColor(this._backgroundColour.r, this._backgroundColour.g, this._backgroundColour.b, 0.0);
         this._gl.clear(this._gl.COLOR_BUFFER_BIT | this._gl.DEPTH_BUFFER_BIT);
     }
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -497,6 +497,22 @@ export class UI {
 
     private _toolbarRight = {
         groups: {
+            'display': {
+                components: {
+                    'grid': new ToolbarItemComponent({ id: 'grid-right', iconSVG: AppIcons.GRID })
+                        .onClick(() => {
+                            Renderer.Get.toggleIsGridEnabled();
+                        })
+                        .isActive(() => {
+                            return Renderer.Get.isGridEnabled();
+                        })
+                        .isEnabled(() => {
+                            return Renderer.Get.getActiveMeshType() !== MeshType.None;
+                        })
+                        .setTooltip('toolbar.toggle_grid'),
+                },
+                componentOrder: ['grid'],
+            },
             'zoom': {
                 components: {
                     'zoomOut': new ToolbarItemComponent({ id: 'zout', iconSVG: AppIcons.MINUS })
@@ -539,7 +555,7 @@ export class UI {
                 componentOrder: ['perspective', 'orthographic'],
             },
         },
-        groupsOrder: ['camera', 'zoom'],
+        groupsOrder: ['camera', 'display', 'zoom'],
     };
 
     private _uiDull: { [key: string]: Group } = this._ui;

--- a/styles.css
+++ b/styles.css
@@ -54,6 +54,7 @@ body {
 canvas {
   width: 100%;
   height: 100%;
+  background: transparent;
 }
 
 .content {
@@ -99,6 +100,7 @@ canvas {
 
 .column-canvas {
   cursor: grab;
+  background: linear-gradient(#1a1d22, #0a0b0c);
 }
 
 .column-console {


### PR DESCRIPTION
## Summary
- make canvas support transparency
- enable gradient background with CSS
- add grid toggle button to the right-side toolbar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547237e998832796e2f9557de7edf0